### PR TITLE
close #63 내가 신청한 미팅 정보 요청시, 신청 id 도 같이 리턴

### DIFF
--- a/src/main/java/com/hangang/HangangRiver/meeting/model/MeetingDetail.java
+++ b/src/main/java/com/hangang/HangangRiver/meeting/model/MeetingDetail.java
@@ -1,8 +1,5 @@
 package com.hangang.HangangRiver.meeting.model;
 
-
-
-
 import java.util.Date;
 
 

--- a/src/main/java/com/hangang/HangangRiver/meeting/service/MyPageService.java
+++ b/src/main/java/com/hangang/HangangRiver/meeting/service/MyPageService.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 @Service
 public class MyPageService extends MeetingBaseService{
-    public List<MeetingDetail> getHopeMeetings(String userID) {
-        List<MeetingDetail> hopeMeetingList = new ArrayList<>();
+    public List<JSONObject> getHopeMeetings(String userID) {
+        List<JSONObject> hopeMeetingList = new ArrayList<>();
 
         // 1. 먼저 내 아이디에 해당하는 모든 join 리스트를 다 가지고 옴
         List<JoinDetail> joinRequests = joinDetailMapper.getJoinDetailsByUserId(userID);
@@ -34,8 +34,13 @@ public class MyPageService extends MeetingBaseService{
                 if(otherContactedMeeting != null) {
                     meetingDetail.setContact_seq(otherContactedMeeting.getContact_seq());
                 }
+
                 if (meetingDetail != null){
-                	hopeMeetingList.add(meetingDetail);
+                    JSONObject hopeMeetingInfo = new JSONObject();
+                    hopeMeetingInfo.put("meeting_detail", meetingDetail);
+                    hopeMeetingInfo.put("application_seq", request.getApplication_seq());
+
+                    hopeMeetingList.add(hopeMeetingInfo);
                 }
             }
         });

--- a/src/main/java/com/hangang/HangangRiver/meeting/web/MyPageController.java
+++ b/src/main/java/com/hangang/HangangRiver/meeting/web/MyPageController.java
@@ -21,7 +21,7 @@ public class MyPageController {
 
     @GetMapping("/{userID}/join/meetings")
     @ResponseBody
-    private ResponseEntity<List<MeetingDetail>> getHopeMeetings(@PathVariable String userID) {
+    private ResponseEntity<List<JSONObject>> getHopeMeetings(@PathVariable String userID) {
         return ResponseEntity.ok().body(myPageService.getHopeMeetings(userID));
     }
 


### PR DESCRIPTION
* 미팅정보 요청 시, 신청 정보의 id 값을 json 타입으로 묶어서 같이 제공

`mypage/{userID}/join/meetings`

```json
{
        "meeting_detail": {
            "meeting_seq": 12,
            "activity_seq": 1,
            "user_id": "user1",
            "description": "설명블라블라",
            "participants_cnt": 4,
            "meeting_location": "만남장소",
            "meeting_time": "2018-07-26 11:38:00",
            "expected_cost": 10000,
            "creation_time": "2018-07-26 11:38:00",
            "modification_time": "2018-07-05 02:13:56",
            "title": "제목",
            "contact": "010-1234-5678",
            "contact_seq": 26,
            "nickname": "유저1"
        },
        "application_seq": 6
},
```