### PR TITLE
close #97 FCM 전송을 위한 로직 추가 및 리펙토링 수행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,4 +210,7 @@ buildNumber.properties
 
 .DS_Store
 
+# FCM
+service-account.json
+
 # End of https://www.gitignore.io/api/git,java,maven,eclipse,intellij,jetbrains

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,18 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.api-client</groupId>
+			<artifactId>google-api-client</artifactId>
+			<version>1.23.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.5</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.mybatis</groupId>
 			<artifactId>mybatis</artifactId>
 			<version>3.3.0</version>

--- a/src/main/java/com/hangang/HangangRiver/access/model/User.java
+++ b/src/main/java/com/hangang/HangangRiver/access/model/User.java
@@ -9,6 +9,15 @@ public class User {
 	private String hangang_token;
 	private Date last_login_time;
 	private Date creation_time;
+	private String fcm_token;
+
+	public String getFcm_token() {
+		return fcm_token;
+	}
+
+	public void setFcm_token(String fcm_token) {
+		this.fcm_token = fcm_token;
+	}
 
 	public String getUser_id() {
 		return user_id;

--- a/src/main/java/com/hangang/HangangRiver/access/service/AccessService.java
+++ b/src/main/java/com/hangang/HangangRiver/access/service/AccessService.java
@@ -27,11 +27,16 @@ public class AccessService {
     	accessMapper.update(user_id, user);
     }
 
-    public User registUser(String user_id, User user) throws ExistUserNickNameException{
-        if(accessMapper.isExistNickname(user.getNickname())) {
+    public User registUser(String user_id, User user) throws Exception {
+        if(user.getNickname() == null) {
+            throw new Exception();
+        }
+
+	    if(accessMapper.isExistNickname(user.getNickname())) {
             throw new ExistUserNickNameException();
         }
-    	accessMapper.update(user_id, user);
+
+    	accessMapper.insert(user);
     	return user;
     }
 }

--- a/src/main/java/com/hangang/HangangRiver/access/web/AccessController.java
+++ b/src/main/java/com/hangang/HangangRiver/access/web/AccessController.java
@@ -33,7 +33,7 @@ public class AccessController {
 	@PostMapping("/loginValidate")
 	private ResponseEntity<User> loginValidate(HttpServletRequest request, @RequestBody User user)
 			throws Exception {
-		return ResponseEntity.ok().body(submitFacebookLogin(user.getAccess_token(),user.getUser_id()));
+		return ResponseEntity.ok().body(submitFacebookLogin(user.getAccess_token(),user.getUser_id(), user));
 	}
 
 	@PostMapping("/registUser")
@@ -42,12 +42,12 @@ public class AccessController {
 		return ResponseEntity.ok().body(accessService.registUser(user.getUser_id(), user));
 	}
 
-	private User submitFacebookLogin(String accessToken, String user_id)
+	private User submitFacebookLogin(String accessToken, String user_id, User paramUser)
 			throws Exception {
 		User faceUser =faceBookUserInfoValidate(accessToken, user_id);//페북에 한번더 검증 요청
 		User userInfo = null;
 		if (faceUser != null){//검증된 경우
-			userInfo = saveUserInfo(faceUser);
+			userInfo = saveUserInfo(faceUser, paramUser);
 		}
 		return userInfo;
 	}
@@ -82,7 +82,7 @@ public class AccessController {
 		}
 	}
 
-	public User saveUserInfo(User user){
+	public User saveUserInfo(User user, User paramUser){
 		Boolean existUser = selectExistUser(user);//최초로그인인지 확인
 		user.setUser_id(user.getUser_id());
 		String hangang_token = hashMD5(user.getAccess_token()+user.getUser_id());
@@ -90,6 +90,7 @@ public class AccessController {
 		if (existUser){
 			accessService.modifyUser(user.getUser_id(), user);//아니면 한강토큰 업뎃
 		}else {
+			user.setFcm_token(paramUser.getFcm_token());
 			accessService.createUser(user);//최초로그인이면 insert
 		}
 		return accessService.getUserDetailById(user.getUser_id());

--- a/src/main/java/com/hangang/HangangRiver/common/web/ExceptionController.java
+++ b/src/main/java/com/hangang/HangangRiver/common/web/ExceptionController.java
@@ -56,7 +56,7 @@ public class ExceptionController {
         return e.getMessage();
     }
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(value = LoginValidateException.class)
     public String handleBaseException(LoginValidateException e){
         logger.error(e.getMessage(), e);
@@ -66,6 +66,20 @@ public class ExceptionController {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(value = ExistUserNickNameException.class)
     public String handleBaseException(ExistUserNickNameException e){
+        logger.error(e.getMessage(), e);
+        return e.getMessage();
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(value = NotExistUserException.class)
+    public String handleBaseException(NotExistUserException e){
+        logger.error(e.getMessage(), e);
+        return e.getMessage();
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(value = NotExistFacebookUserException.class)
+    public String handleBaseException(NotExistFacebookUserException e){
         logger.error(e.getMessage(), e);
         return e.getMessage();
     }

--- a/src/main/java/com/hangang/HangangRiver/common/web/MessageManager.java
+++ b/src/main/java/com/hangang/HangangRiver/common/web/MessageManager.java
@@ -1,0 +1,209 @@
+package com.hangang.HangangRiver.common.web;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+
+import java.io.DataOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class MessageManager {
+    private static final String PROJECT_ID = "hanriver-212300";
+    private static final String BASE_URL = "https://fcm.googleapis.com";
+    private static final String FCM_SEND_ENDPOINT = "/v1/projects/" + PROJECT_ID + "/messages:send";
+
+    private static final String MESSAGING_SCOPE = "https://www.googleapis.com/auth/firebase.messaging";
+    private static final String[] SCOPES = { MESSAGING_SCOPE };
+
+    public static final String MESSAGE_KEY = "message";
+
+    /**
+     * Retrieve a valid access token that can be use to authorize requests to the FCM REST
+     * API.
+     *
+     * @return Access token.
+     * @throws IOException
+     */
+    // [START retrieve_access_token]
+    private static String getAccessToken() throws IOException {
+        GoogleCredential googleCredential = GoogleCredential
+                .fromStream(new FileInputStream("service-account.json"))
+                .createScoped(Arrays.asList(SCOPES));
+        googleCredential.refreshToken();
+        return googleCredential.getAccessToken();
+    }
+    // [END retrieve_access_token]
+
+    /**
+     * Create HttpURLConnection that can be used for both retrieving and publishing.
+     *
+     * @return Base HttpURLConnection.
+     * @throws IOException
+     */
+    private static HttpURLConnection getConnection() throws IOException {
+        // [START use_access_token]
+        URL url = new URL(BASE_URL + FCM_SEND_ENDPOINT);
+        HttpURLConnection httpURLConnection = (HttpURLConnection) url.openConnection();
+        httpURLConnection.setRequestProperty("Authorization", "Bearer " + getAccessToken());
+        httpURLConnection.setRequestProperty("Content-Type", "application/json; UTF-8");
+        return httpURLConnection;
+        // [END use_access_token]
+    }
+
+    /**
+     * Send request to FCM message using HTTP.
+     *
+     * @param fcmMessage Body of the HTTP request.
+     * @throws IOException
+     */
+    private static void sendMessage(JsonObject fcmMessage) throws IOException {
+        HttpURLConnection connection = getConnection();
+        connection.setDoOutput(true);
+        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
+        outputStream.writeBytes(fcmMessage.toString());
+        outputStream.flush();
+        outputStream.close();
+
+        int responseCode = connection.getResponseCode();
+        if (responseCode == 200) {
+            String response = inputstreamToString(connection.getInputStream());
+            System.out.println("Message sent to Firebase for delivery, response:");
+            System.out.println(response);
+        } else {
+            System.out.println("Unable to send message to Firebase:");
+            String response = inputstreamToString(connection.getErrorStream());
+            System.out.println(response);
+        }
+    }
+
+    /**
+     * Build the android payload that will customize how a message is received on Android.
+     *
+     * @return android payload of an FCM request.
+     */
+    private static JsonObject buildAndroidOverridePayload() {
+        JsonObject androidNotification = new JsonObject();
+        androidNotification.addProperty("click_action", "android.intent.action.MAIN");
+
+        JsonObject androidNotificationPayload = new JsonObject();
+        androidNotificationPayload.add("notification", androidNotification);
+
+        return androidNotificationPayload;
+    }
+
+    /**
+     * Build the apns payload that will customize how a message is received on iOS.
+     *
+     * @return apns payload of an FCM request.
+     */
+    private static JsonObject buildApnsHeadersOverridePayload() {
+        JsonObject apnsHeaders = new JsonObject();
+        apnsHeaders.addProperty("apns-priority", "10");
+
+        return apnsHeaders;
+    }
+
+    /**
+     * Build aps payload that will add a badge field to the message being sent to
+     * iOS devices.
+     *
+     * @return JSON object with aps payload defined.
+     */
+    private static JsonObject buildApsOverridePayload() {
+        JsonObject badgePayload = new JsonObject();
+        badgePayload.addProperty("badge", 1);
+
+        JsonObject apsPayload = new JsonObject();
+        apsPayload.add("aps", badgePayload);
+
+        return apsPayload;
+    }
+
+    /**
+     * Send notification message to FCM for delivery to registered devices.
+     *
+     * @throws IOException
+     */
+    public static void sendCommonMessage(String deviceToken, String title, String body) throws IOException {
+        JsonObject notificationMessage = buildNotificationMessageWithDeviceToken(deviceToken, title, body);
+        System.out.println("FCM request body for message using common notification object:");
+        prettyPrint(notificationMessage);
+        sendMessage(notificationMessage);
+    }
+
+
+    public static void sendTopicMessage(String topic, String title, String body) throws IOException {
+        JsonObject notificationMessage = buildNotificationMessage(topic, title, body);
+        System.out.println("FCM request body for message using common notification object:");
+        prettyPrint(notificationMessage);
+        sendMessage(notificationMessage);
+    }
+
+    /**
+     * Construct the body of a notification message request.
+     *
+     * @return JSON of notification message.
+     */
+    private static JsonObject buildNotificationMessageWithDeviceToken(String deviceToken, String title, String body) {
+        JsonObject jNotification = new JsonObject();
+        jNotification.addProperty("title", title);
+        jNotification.addProperty("body", body);
+
+        JsonObject jMessage = new JsonObject();
+        jMessage.add("notification", jNotification);
+        jMessage.addProperty("token", deviceToken);
+
+        JsonObject jFcm = new JsonObject();
+        jFcm.add(MESSAGE_KEY, jMessage);
+
+        return jFcm;
+    }
+
+    private static JsonObject buildNotificationMessage(String topic, String title, String body) {
+        JsonObject jNotification = new JsonObject();
+        jNotification.addProperty("title", title);
+        jNotification.addProperty("body", body);
+
+        JsonObject jMessage = new JsonObject();
+        jMessage.add("notification", jNotification);
+        jMessage.addProperty("topic", topic);
+
+        JsonObject jFcm = new JsonObject();
+        jFcm.add(MESSAGE_KEY, jMessage);
+
+        return jFcm;
+    }
+
+    /**
+     * Read contents of InputStream into String.
+     *
+     * @param inputStream InputStream to read.
+     * @return String containing contents of InputStream.
+     * @throws IOException
+     */
+    private static String inputstreamToString(InputStream inputStream) throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        Scanner scanner = new Scanner(inputStream);
+        while (scanner.hasNext()) {
+            stringBuilder.append(scanner.nextLine());
+        }
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Pretty print a JsonObject.
+     *
+     * @param jsonObject JsonObject to pretty print.
+     */
+    private static void prettyPrint(JsonObject jsonObject) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        System.out.println(gson.toJson(jsonObject) + "\n");
+    }
+}

--- a/src/main/java/com/hangang/HangangRiver/exceptions/NotExistFacebookUserException.java
+++ b/src/main/java/com/hangang/HangangRiver/exceptions/NotExistFacebookUserException.java
@@ -1,0 +1,8 @@
+package com.hangang.HangangRiver.exceptions;
+
+public class NotExistFacebookUserException extends Exception{
+    @Override
+    public String getMessage() {
+        return "페이스북에 가입되지 않은 아이디 입니다.";
+    }
+}

--- a/src/main/java/com/hangang/HangangRiver/exceptions/NotExistUserException.java
+++ b/src/main/java/com/hangang/HangangRiver/exceptions/NotExistUserException.java
@@ -1,0 +1,8 @@
+package com.hangang.HangangRiver.exceptions;
+
+public class NotExistUserException extends Exception{
+    @Override
+    public String getMessage() {
+        return "가입되지 않은 아이디 입니다.";
+    }
+}

--- a/src/main/java/com/hangang/HangangRiver/interceptor/HttpInterceptor.java
+++ b/src/main/java/com/hangang/HangangRiver/interceptor/HttpInterceptor.java
@@ -40,7 +40,10 @@ public class HttpInterceptor extends HandlerInterceptorAdapter {
 		if (checkPath("/configuration", servletPath)) {
 			return true;
 		}
-		if (checkPath("/access/loginValidate", servletPath)) {
+		if (checkPath("/access/login", servletPath)) {
+			return true;
+		}
+		if (checkPath("/access/register", servletPath)) {
 			return true;
 		}
 		String reqHangang_token =request.getHeader("hangang_token");

--- a/src/main/resources/com/hangang/HangangRiver/AccessMapper.xml
+++ b/src/main/resources/com/hangang/HangangRiver/AccessMapper.xml
@@ -5,9 +5,9 @@
 	<insert id="insert" parameterType="com.hangang.HangangRiver.access.model.User">
 		INSERT INTO
 			user
-			(user_id, nickname, access_token, hangang_token, last_login_time, creation_time)
+			(user_id, nickname, access_token, hangang_token, fcm_token, last_login_time, creation_time)
 		VALUES
-			(#{user_id}, #{nickname}, #{access_token}, #{hangang_token}, now(), now())
+			(#{user_id}, #{nickname}, #{access_token}, #{hangang_token}, #{fcm_token}, now(), now())
 	</insert>
 
 	<select id="detail" parameterType="com.hangang.HangangRiver.access.model.User" resultType="com.hangang.HangangRiver.access.model.User">


### PR DESCRIPTION
* FCM 전송을 위한 API 호출 모듈 작성
  - FCM 서버로부터 token을 받아 온 후, 해당토큰과 메시지를 FCM 서버에 전송할 수 있도록 로직 추가
  - service-account.json 파일이 필수적으로 루트 디렉토리에 추가되어야 작동함

* 로그인 로직 변경
  - 기존 페이스북 로그인 체크 시 자동으로 계정이 생성되고(닉네임 없이), 닉네임만 추가하는 식으로 작동하였으나, 로그인 체크와 계정 생성을 별도로 분리
  - 회원가입 및 로그인 시, 최신 디바이스 FCM 토큰 값을 받아오고 이를 DB에 저장

* 코드 리펙토링
  - 불필요한 코드 리펙토링 수행